### PR TITLE
Chore: disable hardware acceleration on android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ export default class Chart extends PureComponent<Props> {
       <WebView
         useWebKit
         javaScriptEnabled
+        androidHardwareAccelerationDisabled
         ref={this.chart}
         scrollEnabled={false}
         style={styles.webView}


### PR DESCRIPTION
https://github.com/react-native-webview/react-native-webview/issues/811#issuecomment-639833153

It solves issue with not rendering charts and with screenshots on android.